### PR TITLE
Change arm-ttk location

### DIFF
--- a/arm-parent/pom.xml
+++ b/arm-parent/pom.xml
@@ -26,7 +26,7 @@
       <artifactsLocationBase>https://raw.githubusercontent.com/${git.repo}</artifactsLocationBase>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <arm.assembly.version>1.0.1</arm.assembly.version>
-      <template.validation.tests.directory>${basedir}/../azure-quickstart-templates/test/arm-ttk</template.validation.tests.directory>
+      <template.validation.tests.directory>${basedir}/../arm-ttk/arm-ttk</template.validation.tests.directory>
       <test.args>-Test all</test.args>
       <test.parameters></test.parameters>
     </properties>


### PR DESCRIPTION
Change arm-ttk location, as Azure Resource Manager Template Toolkit has been moved to https://aka.ms/arm-ttk.