### PR TITLE
Refactor for bin folder

### DIFF
--- a/arm-assembly/pom.xml
+++ b/arm-assembly/pom.xml
@@ -12,7 +12,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.microsoft.azure.iaas</groupId>
   <artifactId>arm-assembly</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
 </project>

--- a/arm-assembly/src/main/resources/assemblies/arm-assembly.xml
+++ b/arm-assembly/src/main/resources/assemblies/arm-assembly.xml
@@ -16,6 +16,7 @@
         <include>mainTemplate.json</include>
         <include>nestedtemplates/**</include>
         <include>**/scripts/*</include>
+        <include>**/bin/*</include>
         <include>utilities/**</include>
       </includes>
     </fileSet>

--- a/arm-parent/pom.xml
+++ b/arm-parent/pom.xml
@@ -14,7 +14,7 @@
   <groupId>com.microsoft.azure.iaas</groupId>
   <artifactId>azure-javaee-iaas-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.15</version>
+  <version>1.0.16</version>
   <name>${project.artifactId}</name>
   <description></description>
 
@@ -23,7 +23,7 @@
     <git.repo>weblogic-azure</git.repo>
     <artifactsLocationBase>https://raw.githubusercontent.com/oracle/${git.repo}</artifactsLocationBase>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <arm.assembly.version>1.0.3</arm.assembly.version>
+    <arm.assembly.version>1.0.4</arm.assembly.version>
     <template.validation.tests.directory>${basedir}/../arm-ttk/arm-ttk</template.validation.tests.directory>
     <test.args>-Test all</test.args>
     <test.parameters></test.parameters>
@@ -66,10 +66,6 @@
                 <resource>
                   <directory>src/main/scripts</directory>
                   <filtering>true</filtering>
-                </resource>
-                <resource>
-                  <directory>src/main/bin</directory>
-                  <filtering>false</filtering>
                 </resource>
               </resources>
             </configuration>
@@ -128,7 +124,23 @@
                 </resource>
               </resources>
             </configuration>
-          </execution>          
+          </execution>
+          <execution>
+            <id>copy-resources-06</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/arm/bin</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/bin</directory>
+                  <filtering>false</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>


### PR DESCRIPTION
To resolve this issue: https://github.com/Azure/rhel-jboss-templates/issues/57

Pack source files under `/bin` to target `/bin` folder in assembly instead of `/scripts` to avoid file structure inconsistency.