### PR TITLE
add config file for external deps versions

### DIFF
--- a/arm-parent/pom.xml
+++ b/arm-parent/pom.xml
@@ -14,7 +14,7 @@
   <groupId>com.microsoft.azure.iaas</groupId>
   <artifactId>azure-javaee-iaas-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.17</version>
+  <version>1.0.18</version>
   <name>${project.artifactId}</name>
   <description></description>
 
@@ -27,8 +27,8 @@
     <template.validation.tests.directory>${basedir}/../arm-ttk/arm-ttk</template.validation.tests.directory>
     <test.args>-Test all</test.args>
     <test.parameters></test.parameters>
-    <test.skip>-Skip apiVersions-Should-Be-Recent-In-Reference-Functions,apiVersions-Should-Be-Recent</test.skip>
-    <template.pid.properties.url>https://raw.githubusercontent.com/Azure/azure-javaee-iaas/master/arm-parent/src/main/resources/default.properties</template.pid.properties.url>
+    <test.skip></test.skip>
+    <template.pid.properties.url>https://raw.githubusercontent.com/Azure/azure-javaee-iaas/main/arm-parent/src/main/resources/default.properties</template.pid.properties.url>
     <template.microsoft.pid.properties.url>${template.pid.properties.url}</template.microsoft.pid.properties.url>
   </properties>
 

--- a/arm-parent/src/main/resources/external-deps-versions.properties
+++ b/arm-parent/src/main/resources/external-deps-versions.properties
@@ -1,0 +1,6 @@
+# This file is a centralized place for managing the versions/references of external
+# dependencies used in pipelines of all Java EE appliation offers across all vendors.
+
+AZ_CLI_VERSION=2.40.0
+BICEP_VERSION=v0.11.1
+ARM_TTK_REFERENCE=06356206f9a8a5173fc124458a1486a1cc67fa31


### PR DESCRIPTION
Centralize the version management for external dependencies (Bicep, az-cli, arm-ttk) used in pipelines of all Java EE application offers across vendors.

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>