### PR TITLE
Add property:skip.exec.plugin

### DIFF
--- a/arm-parent/pom.xml
+++ b/arm-parent/pom.xml
@@ -14,13 +14,14 @@
   <groupId>com.microsoft.azure.iaas</groupId>
   <artifactId>azure-javaee-iaas-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.19</version>
+  <version>1.0.20</version>
   <name>${project.artifactId}</name>
   <description></description>
 
   <properties>
     <git.tag>main</git.tag>
     <git.repo>weblogic-azure</git.repo>
+    <skip.exec.plugin>false</skip.exec.plugin>
     <artifactsLocationBase>https://raw.githubusercontent.com/oracle/${git.repo}</artifactsLocationBase>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <arm.assembly.version>1.0.4</arm.assembly.version>
@@ -194,6 +195,7 @@
               </execution>
             </executions>
             <configuration>
+              <skip>${skip.exec.plugin}</skip>
               <workingDirectory>${template.validation.tests.directory}</workingDirectory>
               <executable>sh</executable>
               <commandlineArgs>Test-AzTemplate.sh -TemplatePath ${project.build.directory}/arm ${test.args} ${test.skip} ${test.parameters}</commandlineArgs>
@@ -218,6 +220,7 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
+                  <skip>${skip.exec.plugin}</skip>
                   <workingDirectory>${project.build.directory}/bicep</workingDirectory>
                   <executable>bicep</executable>
                   <commandlineArgs>build --outdir ${project.build.directory}/arm ${project.build.directory}/bicep/mainTemplate.bicep</commandlineArgs>
@@ -267,6 +270,7 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
+                  <skip>${skip.exec.plugin}</skip>
                   <workingDirectory>${project.build.directory}/bicep</workingDirectory>
                   <executable>bicep</executable>
                   <commandlineArgs>build --outdir ${project.build.directory}/arm ${project.build.directory}/bicep/mainTemplate.bicep</commandlineArgs>


### PR DESCRIPTION
## Context
Refer to bug in this [comments](https://github.com/oracle/weblogic-azure/pull/282#pullrequestreview-1683112699) by @edburns .
In order to address the issue in the [comments](https://github.com/oracle/weblogic-azure/pull/282#pullrequestreview-1683112699), one way we can do is to add a property in the azure-javaee-iaas, in this way, the weblogic-azure will be able to configure to skip some unnecessary maven plugin execution steps which contains errors.

## Description
- Add a property `skip.exec.plugin` to enable the ability to skip the plugin:exec-maven-plugin.
- Upgrade version.

